### PR TITLE
Add next() call to Promise resolutions

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -92,11 +92,13 @@ router.beforeResolve(async (routeTo, routeFrom, next) => {
               next(...args)
               reject(new Error('Redirected'))
             } else {
+              next()
               resolve()
             }
           })
         } else {
           // Otherwise, continue resolving the route.
+          next()
           resolve()
         }
       })


### PR DESCRIPTION
This is a super weird one I encountered while building my app. I noticed when I was logging out and being redirected from `/tracks` to `/login`, the `Tracks` view's `created()` lifecycle hook was being called as I was leaving the page. After adding the `next()` calls as in this PR, it fixed the issue.

My only guess is that the `next()` didn't happen quickly enough and that somehow resulted in the view's `created()` lifecycle hook being called, though I'm not really clear on why. Adding the `next()` call worked. And I figured, looking at line 92 (`next(...args)` before the `reject()` call), it made sense to call `next()` before the `resolve()` calls as well.