### PR TITLE
Feat: Change vuex module state to generator functions

### DIFF
--- a/generators/new/module/module.ejs.t
+++ b/generators/new/module/module.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: src/state/modules/<%= h.changeCase.kebab(name) %>.js
 ---
-export const state = {}
+export const state = () => ({})
 
 export const getters = {}
 

--- a/src/state/modules/auth.js
+++ b/src/state/modules/auth.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
-export const state = {
+export const state = () => ({
   currentUser: getSavedState('auth.currentUser'),
-}
+})
 
 export const mutations = {
   SET_CURRENT_USER(state, newValue) {

--- a/src/state/modules/auth.unit.js
+++ b/src/state/modules/auth.unit.js
@@ -71,6 +71,7 @@ describe('@state/modules/auth', () => {
 
     it('actions.logIn rejects with 401 when NOT already logged in and provided an incorrect username and password', () => {
       expect.assertions(1)
+      store.commit('SET_CURRENT_USER', null)
 
       return store
         .dispatch('logIn', {

--- a/src/state/modules/users.js
+++ b/src/state/modules/users.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
-export const state = {
+export const state = () => ({
   cached: [],
-}
+})
 
 export const getters = {}
 

--- a/tests/unit/matchers.js
+++ b/tests/unit/matchers.js
@@ -93,7 +93,8 @@ customMatchers.toBeAVuexModule = function(options) {
   function isAVuexModule() {
     return (
       _.isPlainObject(options) &&
-      _.isPlainObject(options.state) &&
+      (_.isPlainObject(options.state) ||
+        (_.isFunction(options.state) && _.isPlainObject(options.state()))) &&
       _.isPlainObject(options.getters) &&
       _.isPlainObject(options.mutations) &&
       _.isPlainObject(options.actions)

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -152,7 +152,7 @@ global.createComponentMocks = ({ store, router, style, mocks, stubs }) => {
           const storeModule = store[moduleName]
           return {
             [moduleName]: {
-              state: storeModule.state || {},
+              state: storeModule.state || (() => ({})),
               getters: storeModule.getters || {},
               actions: storeModule.actions || {},
               namespaced:
@@ -188,9 +188,9 @@ global.createModuleStore = (vuexModule, options = {}) => {
     modules: {
       auth: {
         namespaced: true,
-        state: {
+        state: () => ({
           currentUser: options.currentUser,
-        },
+        }),
       },
     },
     // Enable strict mode when testing Vuex modules so that


### PR DESCRIPTION
Switched to using state generator functions instead of an object literal for the vuex state as it's betters for SSR rendering and yields more predictable results.